### PR TITLE
Return integer for method `execute`

### DIFF
--- a/src/Command/ScheduleCommand.php
+++ b/src/Command/ScheduleCommand.php
@@ -68,6 +68,8 @@ class ScheduleCommand extends Command {
         } else {
             throw new InvalidArgumentException(sprintf("It looks like there is already registered service under the '%s' name", ScheduleExtension::$serviceName));
         }
+        
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Since Symfony 4.4, `execute` method need to return an integer.

This Pull Request follow the new console improvements describe here: https://symfony.com/blog/new-in-symfony-4-4-console-improvements